### PR TITLE
Add event feature for sending reminder emails

### DIFF
--- a/plugin_customizations/tribe_events/tribe_events_custom_fields.php
+++ b/plugin_customizations/tribe_events/tribe_events_custom_fields.php
@@ -1,4 +1,5 @@
 <?php
+
 add_action("add_meta_boxes", "compositions_add_top_meta_box");
 
 function compositions_add_top_meta_box()
@@ -10,44 +11,51 @@ function rsvp_metabox_markup()
 {
     global $post;
     wp_nonce_field(basename(__FILE__), "sdrt_rsvp_enabler_nonce");
-    $rsvp_enable = get_post_meta($post->ID, "enable_rsvps", true );
-    $rsvp_form_id = get_post_meta($post->ID, "rsvp_form", true );
-    $rsvps_limit = get_post_meta($post->ID, "rsvps_limit", true );
-    $logged_in_status = get_post_meta($post->ID, "logged_in_status", true );
+    $rsvp_enable      = get_post_meta($post->ID, "enable_rsvps", true);
+    $rsvp_form_id     = get_post_meta($post->ID, "rsvp_form", true);
+    $rsvps_limit      = get_post_meta($post->ID, "rsvps_limit", true);
+    $logged_in_status = get_post_meta($post->ID, "logged_in_status", true);
+    $send_reminder    = get_post_meta($post->ID, 'rsvp_send_reminder', true);
 
-    if ( empty($rsvp_enable) ) {$rsvp_enable = 'enabled';}
-    if ( empty($rsvp_form_id) ) {$rsvp_form_id = '';}
-    if ( empty($rsvps_limit) ) {$rsvps_limit = '0';}
-    if ( empty($logged_in_status) ) {$logged_in_status = 'yes';}
+    if (empty($rsvp_enable)) {
+        $rsvp_enable = 'enabled';
+    }
+    if (empty($rsvp_form_id)) {
+        $rsvp_form_id = '';
+    }
+    if (empty($rsvps_limit)) {
+        $rsvps_limit = '0';
+    }
+    if (empty($logged_in_status)) {
+        $logged_in_status = 'yes';
+    }
     ?>
 
     <style>
         .rsvp_options {
             margin: 10px 0;
         }
+
         .rsvp_options label.main_label {
             font-weight: 700;
             display: block;
-            line-height:2;
+            line-height: 2;
         }
     </style>
 
     <script>
-        jQuery(document).ready(function($) {
+        jQuery(document).ready(function ($) {
 
-            if($('div#enable_rsvps_option input').attr('value') == 'enabled') {
+            if ($('div#enable_rsvps_option input').attr('value') === 'enabled') {
                 $('#rsvps_limit_option_wrap').slideDown("slow");
-            }
-            else {
+            } else {
                 $('#rsvps_limit_option_wrap').slideUp("slow");
             }
 
-            $('div#enable_rsvps_option input[type="radio"]').click(function() {
-                if($(this).attr('value') == 'enabled') {
+            $('div#enable_rsvps_option input[type="radio"]').click(function () {
+                if ($(this).attr('value') === 'enabled') {
                     $('#rsvps_limit_option_wrap').slideDown("slow");
-                }
-
-                else {
+                } else {
                     $('#rsvps_limit_option_wrap').slideUp("slow");
                 }
             });
@@ -57,26 +65,32 @@ function rsvp_metabox_markup()
     <div id="enable_rsvps_option" class="rsvp_options enabler">
         <label for="enable_rsvps" class="main_label">Enable RSVPs</label>
         <fieldset>
-            <label><input name="enable_rsvps" value="enabled" type="radio" <?php  checked( $rsvp_enable, 'enabled' ); ?>> Enabled</label>
+            <label>
+                <input name="enable_rsvps" value="enabled" type="radio" <?php
+                checked($rsvp_enable, 'enabled'); ?>> Enabled</label>
 
-            <label><input name="enable_rsvps" value="disabled" type="radio" <?php  checked( $rsvp_enable, 'disabled' ); ?>> Disabled</label>
+            <label><input name="enable_rsvps" value="disabled" type="radio" <?php
+                checked($rsvp_enable, 'disabled'); ?>> Disabled</label>
         </fieldset>
     </div>
 
     <div id="rsvps_limit_option_wrap" class="rsvp_options options sdrt-hide">
         <?php
-            $forms = Caldera_Forms_Forms::get_forms($with_details = true);
+        $forms = Caldera_Forms_Forms::get_forms($with_details = true);
         ?>
 
         <p>
             <label for="rsvp_form" class="main_label">Choose Your RSVP Form</label>
 
             <select id="rsvp_form" name="rsvp_form">
-                <option disabled value <?php selected( $rsvp_form_id, '' ); ?>> -- Select Your Form -- </option>
+                <option disabled value <?php
+                selected($rsvp_form_id, ''); ?>> -- Select Your Form --
+                </option>
                 <?php
 
-                foreach ( $forms as $form ) {
-                    echo '<option value="' . $form['ID'] . '" ' .  selected( $rsvp_form_id, $form['ID'] ) . '>' . $form['name'] . '</option>';
+                foreach ($forms as $form) {
+                    echo '<option value="' . $form['ID'] . '" ' . selected($rsvp_form_id,
+                            $form['ID']) . '>' . $form['name'] . '</option>';
                 }
 
                 ?>
@@ -85,15 +99,28 @@ function rsvp_metabox_markup()
 
         <p>
             <label for="rsvps_limit" class="main_label">Limit RSVPs</label>
-            <input name="rsvps_limit" type="number" value="<?php echo $rsvps_limit; ?>" id="rsvps_limit">
+            <input name="rsvps_limit" type="number" value="<?php
+            echo $rsvps_limit; ?>" id="rsvps_limit">
         </p>
         <p>
             <label for="logged_in_status" class="main_label">Must Users be Logged In?</label>
-            <fieldset>
-                <label><input name="logged_in_status" value="yes" type="radio" <?php  checked( $logged_in_status, 'yes', true ); ?>> Yes</label>
+        <fieldset>
+            <label><input name="logged_in_status" value="yes" type="radio" <?php
+                checked($logged_in_status, 'yes', true); ?>> Yes</label>
 
-                <label><input name="logged_in_status" value="no" type="radio" <?php  checked( $logged_in_status, 'no', true ); ?>> No</label>
-            </fieldset>
+            <label><input name="logged_in_status" value="no" type="radio" <?php
+                checked($logged_in_status, 'no', true); ?>> No</label>
+        </fieldset>
+        </p>
+        <p>
+            <label for="rsvp_send_reminder" class="main_label">Send reminder the day before</label>
+        <fieldset>
+            <label><input name="rsvp_send_reminder" value="yes" type="radio" <?php
+                checked($send_reminder, 'yes', true); ?>> Yes</label>
+
+            <label><input name="rsvp_send_reminder" value="no" type="radio" <?php
+                checked($send_reminder, 'no', true); ?>> No</label>
+        </fieldset>
         </p>
     </div>
 
@@ -102,47 +129,39 @@ function rsvp_metabox_markup()
 
 add_action("save_post", "save_rsvp_options", 10, 3);
 
+/**
+ * @param int     $post_id
+ * @param WP_Post $post
+ * @param bool    $update
+ *
+ * @return void
+ */
 function save_rsvp_options($post_id, $post, $update)
 {
-    if ( !isset($_POST["sdrt_rsvp_enabler_nonce"] ) || !wp_verify_nonce( $_POST["sdrt_rsvp_enabler_nonce"], basename(__FILE__)) )
-        return $post_id;
-    if( !current_user_can("edit_post", $post_id) )
-        return $post_id;
-    if( defined("DOING_AUTOSAVE") && DOING_AUTOSAVE )
-        return $post_id;
-
-    $slug = "tribe_events";
-
-    if( $slug != $post->post_type )
-        return $post_id;
-
-    $rsvp_enable_value = 'disabled';
-    $rsvps_limit_value = '30';
-    $rsvp_form_value = '';
-    $logged_in_status = 'yes';
-
-    if(isset($_POST["enable_rsvps"]))
-    {
-        $rsvp_enable_value = $_POST["enable_rsvps"];
+    if ( ! isset($_POST["sdrt_rsvp_enabler_nonce"]) || ! wp_verify_nonce($_POST["sdrt_rsvp_enabler_nonce"],
+            basename(__FILE__))) {
+        return;
     }
-    update_post_meta($post_id, "enable_rsvps", $rsvp_enable_value);
 
-    if(isset($_POST["rsvp_form"]))
-    {
-        $rsvp_form_value = $_POST["rsvp_form"];
+    if ( ! current_user_can("edit_post", $post_id)) {
+        return;
     }
-    update_post_meta($post_id, "rsvp_form", $rsvp_form_value);
 
-    if(isset($_POST["rsvps_limit"]))
-    {
-        $rsvps_limit_value = $_POST["rsvps_limit"];
+    if (defined("DOING_AUTOSAVE") && DOING_AUTOSAVE) {
+        return;
     }
-    update_post_meta($post_id, "rsvps_limit", $rsvps_limit_value );
 
-    if(isset($_POST["logged_in_status"]))
-    {
-        $logged_in_status = $_POST["logged_in_status"];
+    if ('tribe_events' !== $post->post_type) {
+        return;
     }
-    update_post_meta($post_id, "logged_in_status", $logged_in_status );
 
+    $update_meta = static function ($key, $default) use ($post_id) {
+        update_post_meta($post_id, $key, $_POST[$key] ?: $default);
+    };
+
+    $update_meta('enable_rsvps', 'disabled');
+    $update_meta('rsvp_form', '');
+    $update_meta('rsvps_limit', '30');
+    $update_meta('logged_in_status', 'yes');
+    $update_meta('rsvp_send_reminder', 'no');
 }

--- a/rsvps/_rsvp.php
+++ b/rsvps/_rsvp.php
@@ -1,7 +1,12 @@
 <?php
 
-require_once( SDRT_FUNCTIONS_DIR . '/rsvps/attendance.php');
-require_once( SDRT_FUNCTIONS_DIR . '/rsvps/admin_menu.php');
+require_once(SDRT_FUNCTIONS_DIR . '/rsvps/attendance.php');
+require_once(SDRT_FUNCTIONS_DIR . '/rsvps/admin_menu.php');
+require_once(SDRT_FUNCTIONS_DIR . '/rsvps/crons.php');
+
+/**
+ * Helper functions for RSVPs
+ */
 
 /**
  * Queries the RSVPs

--- a/rsvps/_rsvp.php
+++ b/rsvps/_rsvp.php
@@ -2,3 +2,47 @@
 
 require_once( SDRT_FUNCTIONS_DIR . '/rsvps/attendance.php');
 require_once( SDRT_FUNCTIONS_DIR . '/rsvps/admin_menu.php');
+
+/**
+ * Queries the RSVPs
+ *
+ * @param array $args additional WP_Query args to overload or add
+ *
+ * @return WP_Post[]|int[]
+ */
+function get_rsvps(array $args = []): array
+{
+    return get_posts($args + [
+            'post_type'        => 'rsvp',
+            'post_status'      => ['publish'],
+            'order'            => 'ASC',
+            'orderby'          => 'meta_value',
+            'meta_key'         => 'volunteer_name',
+            'suppress_filters' => false,
+            'posts_per_page'   => -1,
+            'nopaging'         => true,
+            'no_found_rows'    => true,
+        ]);
+}
+
+/**
+ * Retrieves the rsvps for a given event
+ *
+ * @param int   $event_id
+ * @param array $args additional WP_Query args to add or overload
+ *
+ * @return WP_Post[]|int[]
+ */
+function get_event_rsvps(int $event_id, array $args = []): array
+{
+    $meta_query = $args['meta_query'] ?: [];
+
+    $meta_query[] = [
+        'key'   => 'event_id',
+        'value' => $event_id,
+    ];
+
+    $args['meta_query'] = $meta_query;
+
+    return get_rsvps($args);
+}

--- a/rsvps/admin_menu.php
+++ b/rsvps/admin_menu.php
@@ -34,7 +34,13 @@ $example_fields = array(
 		'desc'    => 'The following email tags are supported: <ul ><li><code>{first_name}</code></li><li><code>{event_title}</code></li></ul>',
 		'sanit'   => 'html',
 	),
-
+    'sdrt_rsvp_upcoming_reminder' => array(
+        'title'   => 'Message',
+        'type'    => 'textarea',
+        'default' => 'Hello World!',
+        'desc'    => 'The following email tags are supported: <ul ><li><code>{first_name}</code></li><li><code>{event_title}</code></li></ul>',
+        'sanit'   => 'html',
+    ),
 );
 
 $example_settings = new HD_WP_Settings_API( $example_options, $example_fields );

--- a/rsvps/admin_menu.php
+++ b/rsvps/admin_menu.php
@@ -34,6 +34,11 @@ $example_fields = array(
 		'desc'    => 'The following email tags are supported: <ul ><li><code>{first_name}</code></li><li><code>{event_title}</code></li></ul>',
 		'sanit'   => 'html',
 	),
+    'sdrt_email_section_3' => array(
+        'title'   => 'Reminder of upcoming event Message',
+        'type'    => 'section',
+        'desc'    => 'This is sent to the volunteers the day before an event if they RSVP\'d to that event.',
+    ),
     'sdrt_rsvp_upcoming_reminder' => array(
         'title'   => 'Message',
         'type'    => 'textarea',

--- a/rsvps/crons.php
+++ b/rsvps/crons.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Checks for any events happening tomorrow. If there are any, then it sends a reminder email to all volunteers that
+ * have provided an RSVP and are planning to attend.
+ */
+function event_rsvp_send_reminder()
+{
+    $tomorrow = new DateTime('+1 day', wp_timezone());
+
+    $events_tomorrow = tribe_get_events([
+        'eventDisplay' => 'day',
+        'eventDate'    => $tomorrow->format('Y-m-d'),
+        'meta_query'   => [
+            [
+                'key'   => 'rsvp_send_reminder',
+                'value' => 'yes',
+            ],
+        ],
+    ]);
+
+    if (empty($events_tomorrow)) {
+        return;
+    }
+
+    foreach ($events_tomorrow as $event) {
+        $rsvps = get_event_rsvps($event->ID, [
+            'meta_query' => [
+                [
+                    'key'   => 'attending',
+                    'value' => 'yes',
+                ],
+            ],
+            'fields'     => 'ids',
+        ]);
+
+        foreach ($rsvps as $rsvp_id) {
+            $volunteer_name  = get_post_meta($rsvp_id, 'volunteer_name', true);
+            $volunteer_email = get_post_meta($rsvp_id, 'volunteer_email', true);
+
+            if (empty($volunteer_email)) {
+                continue;
+            }
+
+            wp_mail(
+                $volunteer_email,
+                "Reminder for {$event->post_title} tomorrow",
+                sdrt_send_email([
+                    'option'      => 'sdrt_rsvp_upcoming_reminder',
+                    'fname'       => trim(explode(',', $volunteer_name)[1] ?: ''),
+                    'event_title' => $event->post_title,
+                ]),
+                [
+                    'From: SD Refugee Tutoring <info@sdrefugeetutoring.com>',
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
Resolves #8 

## Description

This PR adds the ability for attendees to an event to be send a reminder email the day before the event. By default this feature is disabled, but it may be enabled on a per-event basis with the following radio buttons on the edit event screen:
<img src="https://user-images.githubusercontent.com/2024145/104831627-8efc1080-583f-11eb-8044-9905cbad2d17.png" height="300" />

The email to be sent can be set by going to the RSVP Email Settings page:
![image](https://user-images.githubusercontent.com/2024145/104831696-1a75a180-5840-11eb-8b77-cef461534fcd.png)

This PR does not actually schedule the event, as that will be done with a plugin after the PR is merged; this PR creates the function to be scheduled, however.

## Testing Instructions
1. Create or edit an event and set the date to tomorrow
2. Enable the RSVP reminder for that event
3. Go to the RSVP Email Settings page and write a friendly message
4. Add the following _temporary code_ to the bottom of the `crons.php` file:
    ```php
    if ( isset($_GET['test_reminder']) ) {
        event_rsvp_send_reminder();
    }
    ```
5. Go to the dashboard and reload the page with `&test_reminder=1` in the URL query string.
6. Remove the temporary code

**NOTE**: Make sure to either disable the Zoho Email plugin or make sure the attendees being tested have fake emails, otherwise you will make the same mistake as I did and send out real emails to real people! 😬 