### PR TITLE
Add date range CSV exporting for RSVPs

### DIFF
--- a/rsvps/_rsvp.php
+++ b/rsvps/_rsvp.php
@@ -1,8 +1,9 @@
 <?php
 
-require_once(SDRT_FUNCTIONS_DIR . '/rsvps/attendance.php');
-require_once(SDRT_FUNCTIONS_DIR . '/rsvps/admin_menu.php');
-require_once(SDRT_FUNCTIONS_DIR . '/rsvps/crons.php');
+require_once SDRT_FUNCTIONS_DIR . '/rsvps/attendance.php';
+require_once SDRT_FUNCTIONS_DIR . '/rsvps/admin_menu.php';
+require_once SDRT_FUNCTIONS_DIR . '/rsvps/exporter/exporter.php';
+require_once SDRT_FUNCTIONS_DIR . '/rsvps/crons.php';
 
 /**
  * Helper functions for RSVPs
@@ -33,18 +34,19 @@ function get_rsvps(array $args = []): array
 /**
  * Retrieves the rsvps for a given event
  *
- * @param int   $event_id
- * @param array $args additional WP_Query args to add or overload
+ * @param int|int[] $event_id
+ * @param array     $args additional WP_Query args to add or overload
  *
  * @return WP_Post[]|int[]
  */
-function get_event_rsvps(int $event_id, array $args = []): array
+function get_event_rsvps($event_id, array $args = []): array
 {
-    $meta_query = $args['meta_query'] ?: [];
+    $meta_query = $args['meta_query'] ?? [];
 
     $meta_query[] = [
-        'key'   => 'event_id',
-        'value' => $event_id,
+        'key'     => 'event_id',
+        'value'   => $event_id,
+        'compare' => is_array($event_id) ? 'IN' : '=',
     ];
 
     $args['meta_query'] = $meta_query;

--- a/rsvps/exporter/Exporter.php
+++ b/rsvps/exporter/Exporter.php
@@ -1,0 +1,106 @@
+<?php
+
+class Exporter
+{
+    public function init(): void
+    {
+        add_action('export_filters', [$this, 'renderExportFilters']);
+        add_action('export_wp', [$this, 'generateCSV']);
+    }
+
+    public function renderExportFilters(): void
+    {
+        wp_enqueue_script('jquery-ui-datepicker');
+        wp_enqueue_style('jquery-ui-datepicker-style',
+            '//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css');
+
+        require 'filters.php';
+    }
+
+    public function generateCSV($args): void
+    {
+        if ($args['content'] !== 'rsvp') {
+            return;
+        }
+
+        $startDate = new DateTime(sanitize_text_field($_GET['rsvp-start-date']));
+        $endDate   = new DateTime(sanitize_text_field($_GET['rsvp-end-date']));
+        $fileName  = "rsvp_export_{$startDate->format('m-d-Y')}_{$endDate->format('m-d-Y')}.csv";
+
+        ob_clean();
+        header('Content-Description: File Transfer');
+        header('Content-Disposition: attachment; filename=' . $fileName);
+        header('Content-Type: text/csv; charset=' . get_option('blog_charset'), true);
+
+        $events = tribe_get_events([
+            'start_date'     => $startDate->format('Y-m-d H:i:s'),
+            'end_date'       => $endDate->format('Y-m-d H:i:s'),
+            'posts_per_page' => -1,
+        ]);
+
+        $getEvent = static function (int $eventId) use ($events): ?WP_Post {
+            foreach ($events as $event) {
+                if ($event->ID === $eventId) {
+                    return $event;
+                }
+            }
+
+            return null;
+        };
+
+        $rsvps = get_event_rsvps(wp_list_pluck($events, 'ID'));
+
+        $fields = [
+            'volunteer_email',
+            'volunteer_user_id',
+            'attended',
+        ];
+
+        echo implode(',', [
+                'RSVP ID',
+                'Volunteer First Name',
+                'Volunteer Last Name',
+                'Volunteer Email',
+                'Volunteer User ID',
+                'Attended',
+                'RSVP Date',
+                'Event ID',
+                'Event Name',
+                'Event Date',
+            ]) . "\r\n";
+
+        foreach ($rsvps as $rsvp) {
+            $row = [
+                $rsvp->ID,
+            ];
+
+            // Get data from meta
+            $meta = get_post_meta($rsvp->ID);
+
+            $name  = explode(',', $meta['volunteer_name'][0] ?? '');
+            $row[] = trim($name[0] ?? '');
+            $row[] = trim($name[1] ?? '');
+
+            foreach ($fields as $metaKey) {
+                $row[] = $meta[$metaKey][0] ?? '';
+            }
+
+            $rsvpDate = new DateTime($meta['rsvp_date'][0]);
+            $row[] = $rsvpDate->format('Y-m-d');
+
+            // Get data from event
+            $event = $getEvent((int)$meta['event_id'][0]);
+            if ($event !== null) {
+                $row[] = $event->ID;
+                $row[] = '"' . $event->post_title . '"';
+                $row[] = $event->_EventStartDate;
+            }
+
+            echo implode(',', $row) . "\r\n";
+        }
+
+        exit();
+    }
+}
+
+(new Exporter())->init();

--- a/rsvps/exporter/filters.php
+++ b/rsvps/exporter/filters.php
@@ -1,0 +1,32 @@
+<ul id="rsvp-filters" class="export-filters">
+    <li>
+        <label>
+            <fieldset>
+                <legend class="label">Event Dates:</legend>
+                <label for="rsvp-start-date" class="label-responsive">Start date:</label>
+                <input type="text" name="rsvp-start-date" value="<?= date('m/d/Y', strtotime('-30 days')) ?>" />
+                <label for="rsvp-end-date" class="label-responsive">End date:</label>
+                <input type="text" name="rsvp-end-date" value="<?= date('m/d/Y') ?>" />
+            </fieldset>
+        </label>
+    </li>
+</ul>
+
+<script>
+    jQuery(document).ready(function($) {
+        const $rsvpFilters = $('#rsvp-filters');
+
+        $('input[name="rsvp-start-date"]').datepicker();
+        $('input[name="rsvp-end-date"]').datepicker();
+
+        // Move after rsvp radio button
+        $('input:radio[value="rsvp"]').closest('p').after($rsvpFilters)
+
+        // Display when rsvp radio is selected
+        $('#export-filters input:radio').change(function() {
+            if ( $(this).val() === 'rsvp' ) {
+                $rsvpFilters.slideDown();
+            }
+        })
+    });
+</script>


### PR DESCRIPTION
Resolves #28 

## Description

This improves the Tools > Export utility for RSVPs. Instead of exporting the large XML file, it provides a _much_ faster and simpler CSV file that can be used in any spreadsheet program. The name and date of the event RSVP'd for are also included for each line.

It also gives start and end date to limit the range of RSVPs to download. By default the export range is the last 30 days.

## Visuals

![image](https://user-images.githubusercontent.com/2024145/109436616-43f42200-79d5-11eb-871a-93d2b043956c.png)
