### PR TITLE
Add ability to send no-show email to attendees

### DIFF
--- a/assets/event-single.js
+++ b/assets/event-single.js
@@ -3,6 +3,10 @@ jQuery(document).ready(function ($) {
         const $this = $(this);
         event.preventDefault();
 
+        if (!window.confirm('Are you sure you want to send an email to ' + $this.data('email') + '?')) {
+            return;
+        }
+
         $.post({
             url: rsvpExports.ajaxUrl,
             data: {
@@ -16,7 +20,13 @@ jQuery(document).ready(function ($) {
                 console.error(data);
             }
 
-            $this.replaceWith('<span>Sent!</span>')
+            $this.replaceWith('<span>Sent!</span>');
         });
+    });
+
+    $('.js-delete-rsvp').on('click', function (event) {
+        if (!window.confirm('Are you sure you want to delete the RSVP for ' + $(this).data('name') + '?')) {
+            event.preventDefault();
+        }
     });
 });

--- a/assets/event-single.js
+++ b/assets/event-single.js
@@ -1,0 +1,22 @@
+jQuery(document).ready(function ($) {
+    $('.attended-email').on('click', function (event) {
+        const $this = $(this);
+        event.preventDefault();
+
+        $.post({
+            url: rsvpExports.ajaxUrl,
+            data: {
+                action: 'sdrt_rsvp_email_no_show',
+                nonce: rsvpExports.nonce,
+                rsvp_id: $this.data('rsvpId'),
+            },
+        }).then(function (data) {
+            if (!data.success) {
+                alert('Failed to send email. Please contact admin.');
+                console.error(data);
+            }
+
+            $this.replaceWith('<span>Sent!</span>')
+        });
+    });
+});

--- a/assets/rsvp-styles.css
+++ b/assets/rsvp-styles.css
@@ -74,24 +74,33 @@
     font-size: 120%;
 }
 
-.rwd-table td[data-th="attended"] span.dashicons {
+.rwd-table td span.dashicons {
     overflow: hidden;
     text-indent: 50px;
     width: 2rem;
     height: 2rem;
 }
 
-.rwd-table td[data-th="attended"] span.dashicons:before {
+.rwd-table td span.dashicons:before {
     position: relative;
     right: 50px;
 }
 
-.button.attended {
+.rwd-table td span.dashicons-editor-help:before {
+    position: relative;
+    right: 57px;
+}
+
+.button.action {
     background-color: transparent !important;
 }
 
-.button.attended:hover {
+.button.action:hover {
     opacity: 0.5;
+}
+
+.button.delete-rsvp {
+    margin-right: 0.5em;
 }
 
 @media (min-width: 480px) {

--- a/assets/rsvp-styles.css
+++ b/assets/rsvp-styles.css
@@ -86,6 +86,10 @@
     right: 50px;
 }
 
+.button.attended-no, .button.attended-unknown {
+    background-color: transparent !important;
+}
+
 .button.attended-unknown:hover,
 .button.attended-no:hover {
     opacity: 0.5;

--- a/assets/rsvp-styles.css
+++ b/assets/rsvp-styles.css
@@ -86,12 +86,11 @@
     right: 50px;
 }
 
-.button.attended-no, .button.attended-unknown {
+.button.attended {
     background-color: transparent !important;
 }
 
-.button.attended-unknown:hover,
-.button.attended-no:hover {
+.button.attended:hover {
     opacity: 0.5;
 }
 

--- a/plugin_customizations/_plugins.php
+++ b/plugin_customizations/_plugins.php
@@ -5,7 +5,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 	return false;
 } else {
 	require_once( SDRT_FUNCTIONS_DIR . '/plugin_customizations/tribe_events/tribe_events_customizations.php' );
-	require_once( SDRT_FUNCTIONS_DIR . '/plugin_customizations/tribe_events/tribe_events_custom_fields.php' );
+    require_once( SDRT_FUNCTIONS_DIR . '/plugin_customizations/tribe_events/tribe_events_custom_fields.php' );
+	require_once( SDRT_FUNCTIONS_DIR . '/plugin_customizations/tribe_events/tribe_events_scripts.php' );
 }
 
 if ( ! class_exists( 'Give' ) ) {

--- a/plugin_customizations/tribe_events/tribe_events_customizations.php
+++ b/plugin_customizations/tribe_events/tribe_events_customizations.php
@@ -11,168 +11,163 @@
 
 add_action('tribe_events_single_event_after_the_meta', 'embed_rsvp_events_single');
 
-function embed_rsvp_events_single() {
-	global $post;
+function embed_rsvp_events_single()
+{
+    global $post;
 
-	$get_limit      = get_post_meta( get_the_ID(), 'rsvps_limit', true );
-	$rsvp_enabled   = get_post_meta( get_the_ID(), 'enable_rsvps', true );
-	$must_login     = get_post_meta( get_the_ID(), 'logged_in_status', true );
-	$rsvp_form      = get_post_meta( get_the_ID(), 'rsvp_form', true );
-	$rsvp_limit     = ( !empty($get_limit) ? $get_limit : '');
-	$eventdate      = get_post_meta($post->ID, '_EventStartDate', true);
-	$rsvps          = get_current_rsvps($post->ID);
-	$rsvpmeta       = get_current_rsvps_volids($post->ID);
-	$userid         = get_current_user_id();
-	$rsvp_total     = count($rsvps);
+    $get_limit    = get_post_meta(get_the_ID(), 'rsvps_limit', true);
+    $rsvp_enabled = get_post_meta(get_the_ID(), 'enable_rsvps', true);
+    $must_login   = get_post_meta(get_the_ID(), 'logged_in_status', true);
+    $rsvp_form    = get_post_meta(get_the_ID(), 'rsvp_form', true);
+    $rsvp_limit   = (! empty($get_limit) ? $get_limit : '');
+    $eventdate    = get_post_meta($post->ID, '_EventStartDate', true);
+    $rsvps        = get_current_rsvps($post->ID);
+    $rsvpmeta     = get_current_rsvps_volids($post->ID);
+    $userid       = get_current_user_id();
+    $rsvp_total   = count($rsvps);
 
-	// Only output if RSVPs are enabled for this Event
-	if ( $rsvp_enabled == 'enabled' ) : ?>
+    // Only output if RSVPs are enabled for this Event
+    if ($rsvp_enabled !== 'enabled') {
+        return;
+    }
+    ?>
 
-        <div class="tutoring-rsvp">
-            <h2 class="give-title">RSVP HERE:</h2>
+    <div class="tutoring-rsvp">
+        <h2 class="give-title">RSVP HERE:</h2>
 
-			<?php
+        <?php
 
-			// Show RSVP form if login is not required
-			if ( $must_login == 'no' ) {
-
-				// Show message if RSVP limit is reached
-				if ( $rsvp_limit > 0 && $rsvp_total >= $rsvp_limit ) {
-
-				    sdrt_rsvp_limit_reached_output();
-
-				} else {
-
-				    echo '<p>We currently need <strong>' . abs($rsvp_limit - $rsvp_total) . '</strong> more tutors.</p>';
-					echo do_shortcode('[caldera_form id="' . $rsvp_form . '"]');
-
-				}
-
+        // Show RSVP form if login is not required
+        if ($must_login == 'no') {
+            // Show message if RSVP limit is reached
+            if ($rsvp_limit > 0 && $rsvp_total >= $rsvp_limit) {
+                sdrt_rsvp_limit_reached_output();
+            } else {
+                echo '<p>We currently need <strong>' . abs($rsvp_limit - $rsvp_total) . '</strong> more tutors.</p>';
+                echo do_shortcode('[caldera_form id="' . $rsvp_form . '"]');
+            }
             // Inform visitor to register if login is required
-			} elseif ( $must_login == 'yes') {
+        } elseif ($must_login == 'yes') {
+            $can_rsvp = sdrt_vol_can_rsvp();
 
-				$can_rsvp = sdrt_vol_can_rsvp();
+            // Not logged in
+            if ( ! is_user_logged_in()) {
+                sdrt_rsvp_please_register_output();
+            }
 
-				// Not logged in
-				if ( ! is_user_logged_in() ) {
-					sdrt_rsvp_please_register_output();
-				}
+            if ($can_rsvp == false) {
+                sdrt_finish_reqs();
+            }
 
-				if ( $can_rsvp == false) {
-					sdrt_finish_reqs();
-				}
-
-				if ( is_user_logged_in() && ($can_rsvp == true) ) {
-
-				    // If already RSVP'd
-				    if ( in_array( $userid, $rsvpmeta ) ) {
-
-					    sdrt_rsvp_already_rsvpd_output($post->ID);
-
-					// If RSVPs are full
-				    } elseif ( $rsvp_limit > 0 && $rsvp_total >= $rsvp_limit ) {
-
-				        sdrt_rsvp_limit_reached_output();
-
-				    // RSVPs are open and volunteer can RSVP
-				    }  else {
-					    echo '<p>We currently need <strong>' . abs( $rsvp_limit - $rsvp_total ) . '</strong> more tutors.</p>';
-					    echo do_shortcode( '[caldera_form id="' . $rsvp_form . '"]' );
-				    }
-
-				} elseif ( is_user_logged_in() && ! current_user_can('can_rsvp')) {
-				    echo '<p>It looks like you\'ve completed your background check, but it has not yet cleared. Please come back later or contact our Webmaster via our <a href="' .  get_home_url() . '/contact/">contact form</a> for questions.</p>';
+            if (is_user_logged_in() && ($can_rsvp == true)) {
+                // If already RSVP'd
+                if (in_array($userid, $rsvpmeta)) {
+                    sdrt_rsvp_already_rsvpd_output($post->ID);
+                    // If RSVPs are full
+                } elseif ($rsvp_limit > 0 && $rsvp_total >= $rsvp_limit) {
+                    sdrt_rsvp_limit_reached_output();
+                    // RSVPs are open and volunteer can RSVP
+                } else {
+                    echo '<p>We currently need <strong>' . abs($rsvp_limit - $rsvp_total) . '</strong> more tutors.</p>';
+                    echo do_shortcode('[caldera_form id="' . $rsvp_form . '"]');
                 }
-			}
-			?>
-        </div><!-- end RSVP section -->
+            } elseif (is_user_logged_in() && ! current_user_can('can_rsvp')) {
+                echo '<p>It looks like you\'ve completed your background check, but it has not yet cleared. Please come back later or contact our Webmaster via our <a href="' . get_home_url() . '/contact/">contact form</a> for questions.</p>';
+            }
+        }
+        ?>
+    </div><!-- end RSVP section -->
 
-		<?php
+    <?php
 
-		// Outputs the RSVP Registration Table
-		// Volunteers can register their attendance
-		// by clicking on the "X" next to their name
-		// This is only viewable by a logged-in Admin account
+    // Outputs the RSVP Registration Table
+    // Volunteers can register their attendance
+    // by clicking on the "X" next to their name
+    // This is only viewable by a logged-in Admin account
 
-		if ( !empty( $rsvps ) && current_user_can( 'can_view_rsvps' ) ) :
+    if (empty($rsvps) || ! current_user_can('can_view_rsvps')) {
+        return;
+    }
 
-			$createDate = new DateTime($eventdate);
-			$finaldate = $createDate->format('F d, Y');
-			?>
+    $createDate = new DateTime($eventdate);
+    $finaldate  = $createDate->format('F d, Y');
+    ?>
 
-            <h2 class="give-title current_rsvps" id="rsvps">Current RSVPS:</h2>
+    <h2 class="give-title current_rsvps" id="rsvps">Current RSVPS:</h2>
 
-            <button class="rsvp-download">Print RSVPs</button>
+    <button class="rsvp-download">Print RSVPs</button>
 
-            <table class="rwd-table" id="rsvp-table"  width="100%">
-                <thead>
-                <th colspan="4">
-                    Tutoring on <?php echo $finaldate; ?>
-                </th>
-                </thead>
-                <tr class="labels">
-                    <td><strong>Name</strong></td>
-                    <td><strong>Email</strong></td>
-                    <td><strong>Attended?</strong></td>
-                    <td><strong>Actions</strong></td>
-                </tr>
-				<?php
+    <table class="rwd-table" id="rsvp-table" width="100%">
+        <th colspan="4">
+            Tutoring on <?php
+            echo $finaldate; ?>
+        </th>
+        <tr class="labels">
+            <td><strong>Name</strong></td>
+            <td><strong>Email</strong></td>
+            <td><strong>Attended?</strong></td>
+            <td><strong>Actions</strong></td>
+        </tr>
+        <?php
 
-				foreach( $rsvps as $rsvp ) {
+        foreach ($rsvps as $rsvp) {
+            $rsvpid = $rsvp->ID;
 
-					$rsvpid = $rsvp->ID;
+            $name  = get_post_meta($rsvpid, 'volunteer_name', true);
+            $email = get_post_meta($rsvpid, 'volunteer_email', true);
 
-					$name = get_post_meta($rsvpid, 'volunteer_name', true);
-					$email = get_post_meta($rsvpid, 'volunteer_email', true);
+            $getname = explode(',', $name);
 
-					$getname = explode(',', $name);
+            $firstname = (strpos($name, ',') ? $getname[1] : $name);
 
-					$firstname = ( strpos($name, ',') ? $getname[1] : $name );
+            $attending       = get_post_meta($rsvpid, 'attending', true);
+            $attended        = get_post_meta($rsvpid, 'attended', true);
+            $attendancenonce = wp_create_nonce('sdrt_attendance_nonce');
+            $eventUrl        = get_permalink(get_the_ID());
+            $setAttendedUrl  = "$eventUrl?rsvpid=$rsvpid&attended=yes&_nonce=$attendancenonce&email=$email&fname=$firstname#rsvps";
 
-					//list($firstname)=explode(',', $name);
-
-                    $attending = get_post_meta($rsvpid, 'attending', true);
-					$attended = get_post_meta($rsvpid, 'attended', true);
-					$attendancenonce = wp_create_nonce( 'sdrt_attendance_nonce' );
-					if ($attending !== 'no') {
-                        ?>
-                        <tr>
-                            <td data-th="name" width="40%"><?php echo $name; ?></td>
-                            <td data-th="email" width="40%"><?php echo $email; ?></td>
-                            <?php if ($attended == 'no') { ?>
-                                <td data-th="attended" width="20%"><a
-                                            href="<?php echo get_permalink(get_the_ID()) . '?rsvpid=' . $rsvpid . '&attended=yes&_nonce=' . $attendancenonce . '&email=' . $email . '&fname=' . $firstname . '#rsvps'; ?>"
-                                            class="button attended-no"><span class="dashicons dashicons-no"
-                                                                             style="border-radius: 50%; background: darkred; color: white; padding: 6px;"
-                                                                             title="Click to change to Yes">No</span></a>
-                                </td>
-                            <?php } elseif ($attended == 'unknown') { ?>
-                                <td data-th="attended" width="20%"><a
-                                            href="<?php echo get_permalink(get_the_ID()) . '?rsvpid=' . $rsvpid . '&attended=yes&_nonce=' . $attendancenonce . '&email=' . $email . '&fname=' . $firstname . '#rsvps'; ?>>"
-                                            class="button attended-unknown"><span class="dashicons dashicons-minus"
-                                                                                  style="border-radius: 50%; background: #777777; color: white; padding: 6px;"
-                                                                                  title="Click to change to Yes">Unknown</span></a>
-                                </td>
-                            <?php } else { ?>
-                                <td data-th="attended" width="20%"><span class="dashicons dashicons-yes"
-                                                                         style="border-radius: 50%; background: forestgreen; color: white; padding: 6px;">Yes</span>
-                                </td>
-                            <?php } ?>
-                            <td><a href="<?php echo get_delete_post_link($rsvpid); ?>">Delete</a></td>
-                        </tr>
-
+            if ($attending !== 'no') {
+                ?>
+                <tr>
+                    <td data-th="name" width="40%"><?php
+                        echo $name; ?></td>
+                    <td data-th="email" width="40%"><?php
+                        echo $email; ?></td>
+                    <td data-th="attended" width="20%">
                         <?php
+                        if ($attended === 'no'): ?>
+                            <a href="<?= $setAttendedUrl ?>" class="button attended-no">
+                                <span class="dashicons dashicons-no"
+                                      style="border-radius: 50%; background: darkred; color: white; padding: 6px;"
+                                      title="Click to change to Yes">No</span>
+                            </a>
+                        <?php
+                        elseif ($attended === 'unknown'): ?>
+                            <a href="<?= $setAttendedUrl ?>" class="button attended-unknown">
+                                <span class="dashicons dashicons-minus"
+                                      style="border-radius: 50%; background: #777777; color: white; padding: 6px;"
+                                      title="Click to change to Yes">Unknown</span>
+                            </a>
+                        <?php
+                        else: ?>
+                            <span class="dashicons dashicons-yes"
+                                  style="border-radius: 50%; background: forestgreen; color: white; padding: 6px;">Yes</span>
+                        <?php
+                        endif; ?>
+                    </td>
+                    <td><a href="<?php
+                        echo get_delete_post_link($rsvpid); ?>">Delete</a></td>
+                </tr>
 
-                    }
-				}
-				wp_reset_postdata();
+                <?php
+            }
+        }
+        wp_reset_postdata();
 
-				?>
-            </table>
+        ?>
+    </table>
 
-			<?php
-		endif;
-	endif;
+    <?php
 }
 
 /**
@@ -180,37 +175,35 @@ function embed_rsvp_events_single() {
  *  Returns: true
  */
 
- function sdrt_vol_can_rsvp() {
-	$allowed = true;
-	$userid = get_current_user_id();
+function sdrt_vol_can_rsvp(): bool
+{
+    $userid = get_current_user_id();
 
-	$role = current_user_can('can_rsvp');
-	$orientation = get_user_meta( $userid, 'sdrt_orientation_attended', false );
-	$coc = get_user_meta( $userid, 'sdrt_coc_consented', false );
-	$waiver = get_user_meta( $userid, 'sdrt_waiver_consented', false );
+    $role        = current_user_can('can_rsvp');
+    $orientation = get_user_meta($userid, 'sdrt_orientation_attended', true);
+    $coc         = get_user_meta($userid, 'sdrt_coc_consented', true);
+    $waiver      = get_user_meta($userid, 'sdrt_waiver_consented', true);
 
-	if ($role = false) { $allowed = false; }
-	if ($orientation[0] == 'No') { $allowed = false; }
-	if ($coc[0] == 'No') { $allowed = false; }
-	if ($waiver[0] == 'No') { $allowed = false; }
-	
-	return $allowed;
- }
+    return $role
+           && $orientation !== 'No'
+           && $coc !== 'No'
+           && $waiver !== 'No';
+}
 
- /**
-  *  OUTPUT: Please Finish Volunteer Requirements
-  */
+/**
+ *  OUTPUT: Please Finish Volunteer Requirements
+ */
 
-function sdrt_finish_reqs() {
+function sdrt_finish_reqs()
+{
+    $userid = get_current_user_id();
 
-	$userid = get_current_user_id();
+    $role        = current_user_can('can_rsvp');
+    $orientation = get_user_meta($userid, 'sdrt_orientation_attended', false);
+    $coc         = get_user_meta($userid, 'sdrt_coc_consented', false);
+    $waiver      = get_user_meta($userid, 'sdrt_waiver_consented', false);
 
-	$role = current_user_can('can_rsvp');
-	$orientation = get_user_meta( $userid, 'sdrt_orientation_attended', false );
-	$coc = get_user_meta( $userid, 'sdrt_coc_consented', false );
-	$waiver = get_user_meta( $userid, 'sdrt_waiver_consented', false );
-
-	echo '<p>Thank you for starting the process of volunteering with SD Refugee Tutoring. Currently you are not yet eligble to volunteer for tutoring events. Please go to your <a href="' . get_home_url() . '/my-profile">Profile Page</a> to review your status and finish your required items.</p>';
+    echo '<p>Thank you for starting the process of volunteering with SD Refugee Tutoring. Currently you are not yet eligble to volunteer for tutoring events. Please go to your <a href="' . get_home_url() . '/my-profile">Profile Page</a> to review your status and finish your required items.</p>';
 }
 
 /**
@@ -219,35 +212,43 @@ function sdrt_finish_reqs() {
  * @param int $eventId
  */
 
-function sdrt_rsvp_already_rsvpd_output($eventId) {
-	$rsvp = get_my_rsvp($eventId);
-	$attending = get_post_meta($rsvp->ID, 'attending', true);
+function sdrt_rsvp_already_rsvpd_output($eventId)
+{
+    $rsvp      = get_my_rsvp($eventId);
+    $attending = get_post_meta($rsvp->ID, 'attending', true);
 
-	if ($attending === 'no') {
-    ?>
+    if ($attending === 'no') {
+        ?>
         <div class="already-rsvpd-no">
             <p><strong>Thanks for the heads up</strong></p>
             <p>It looks like you've already RSVP'd for this event. Sorry to hear you can't make it this time</p>
-            <p>Please take a look at <a href="<?php echo esc_url( Tribe__Events__Main::instance()->getLink() ); ?>">all our tutoring sessions</a> for more opportunities to volunteer.</p>
+            <p>Please take a look at <a href="<?php
+                echo esc_url(Tribe__Events__Main::instance()->getLink()); ?>">all our tutoring sessions</a> for more
+                opportunities to volunteer.</p>
         </div>
-    <?php } else { ?>
+        <?php
+    } else { ?>
         <div class="already-rsvpd-yes">
             <p><strong>Thanks!</strong></p>
             <p>It looks like you've already RSVP'd for this event. We look forward to seeing you there!</p>
-            <p>Need to cancel? <a href="<?php echo get_delete_post_link($rsvp->ID); ?>">Click here</a>.</p>
+            <p>Need to cancel? <a href="<?php
+                echo get_delete_post_link($rsvp->ID); ?>">Click here</a>.</p>
         </div>
-    <?php }
+        <?php
+    }
 }
 
 /**
  *  OUTPUT: RSVP LIMIT REACHED
  */
 
-function sdrt_rsvp_limit_reached_output() { ?>
+function sdrt_rsvp_limit_reached_output()
+{ ?>
     <div class="rsvps-closed">
         <p><strong>Sorry!</strong></p>
         <p>We already have the max number of Volunteers we need for this session.</p>
-        <p>Please see our <a href="<?php echo site_url(); ?>/events">full Calendar</a> for future Tutoring Opportunities.</p>
+        <p>Please see our <a href="<?php
+            echo site_url(); ?>/events">full Calendar</a> for future Tutoring Opportunities.</p>
     </div>
     <?php
 }
@@ -257,14 +258,18 @@ function sdrt_rsvp_limit_reached_output() { ?>
  *  OUTPUT: PLEASE REGISTER OUTPUT
  */
 
-function sdrt_rsvp_please_register_output() { ?>
+function sdrt_rsvp_please_register_output()
+{ ?>
     <div class="please-register">
         <p><strong>Please Register to RSVP</strong></p>
-        <p>All volunteers must first be registered and have passed a background check in order to RSVP. Please visit the <a href="<?php echo site_url(); ?>/volunteer">Registration page</a> for details.</p>
+        <p>All volunteers must first be registered and have passed a background check in order to RSVP. Please visit the
+            <a href="<?php
+            echo site_url(); ?>/volunteer">Registration page</a> for details.</p>
         <p><strong>Already Registered? Please Login</strong></p>
-		<?php echo do_shortcode( '[caldera_form id="CF597578b115ae1"]' ); ?>
+        <?php
+        echo do_shortcode('[caldera_form id="CF597578b115ae1"]'); ?>
     </div>
-	<?php
+    <?php
 }
 
 /**
@@ -275,25 +280,26 @@ function sdrt_rsvp_please_register_output() { ?>
  * @return WP_Post[]
  */
 
-function get_current_rsvps($eventId) {
-	$args = array(
-		'post_type'     => 'rsvp',
-		'post_status'   => array('publish'),
-		'order'         => 'ASC',
-		'orderby'       => 'meta_value',
-		'meta_key'      => 'volunteer_name',
-		'nopaging'		=> true,
-		'posts_per_page'=>-1,
-		'no_found_rows' => true,  // turn off pagination
-		'meta_query'    => array(
-			array(
-				'key'     => 'event_id',
-				'value'   => $eventId,
-			),
-		),
-	);
+function get_current_rsvps($eventId)
+{
+    $args = [
+        'post_type'      => 'rsvp',
+        'post_status'    => ['publish'],
+        'order'          => 'ASC',
+        'orderby'        => 'meta_value',
+        'meta_key'       => 'volunteer_name',
+        'nopaging'       => true,
+        'posts_per_page' => -1,
+        'no_found_rows'  => true,  // turn off pagination
+        'meta_query'     => [
+            [
+                'key'   => 'event_id',
+                'value' => $eventId,
+            ],
+        ],
+    ];
 
-	$loop = new WP_Query( $args );
+    $loop = new WP_Query($args);
 
     return $loop->get_posts();
 }
@@ -306,15 +312,16 @@ function get_current_rsvps($eventId) {
  * @return array
  */
 
-function get_current_rsvps_volids($eventId) {
+function get_current_rsvps_volids($eventId)
+{
     global $wpdb;
-	$rsvps = get_current_rsvps($eventId);
+    $rsvps = get_current_rsvps($eventId);
 
-	$rsvpIds = wp_list_pluck($rsvps, 'ID');
-	$placeholders = implode(',', array_fill(0, count($rsvpIds), '%d'));
+    $rsvpIds      = wp_list_pluck($rsvps, 'ID');
+    $placeholders = implode(',', array_fill(0, count($rsvpIds), '%d'));
 
-	return $wpdb->get_col(
-	    $wpdb->prepare(
+    return $wpdb->get_col(
+        $wpdb->prepare(
             "SELECT meta_value from {$wpdb->postmeta} WHERE meta_key = 'volunteer_user_id' AND post_id IN ($placeholders)",
             $rsvpIds
         )
@@ -329,18 +336,17 @@ function get_current_rsvps_volids($eventId) {
  * @return WP_Post[]
  */
 
-function get_my_rsvp($eventId) {
-	$rsvps = get_current_rsvps($eventId);
+function get_my_rsvp($eventId)
+{
+    $rsvps = get_current_rsvps($eventId);
 
-	foreach( $rsvps as $rsvp ) {
-		$ids = $rsvp->ID;
-		$volid[] = get_post_meta($ids, 'volunteer_user_id', true);
-		$userid  = get_current_user_id();
+    foreach ($rsvps as $rsvp) {
+        $ids     = $rsvp->ID;
+        $volid[] = get_post_meta($ids, 'volunteer_user_id', true);
+        $userid  = get_current_user_id();
 
-		if ( in_array( $userid, $volid ) ) {
-		    return $rsvp;
+        if (in_array($userid, $volid)) {
+            return $rsvp;
         }
-
-	}
-
+    }
 }

--- a/plugin_customizations/tribe_events/tribe_events_customizations.php
+++ b/plugin_customizations/tribe_events/tribe_events_customizations.php
@@ -140,15 +140,9 @@ function embed_rsvp_events_single()
                     <td data-th="attended" width="20%">
                         <?php
                         if ($attended === 'no' || $attended === 'unknown'): ?>
-                            <a href="<?= $setAttendedUrl ?>" class="button attended attended-<?= $attended ?>">
-                                <span class="dashicons dashicons-<?= $attended ?>"
-                                      style="border-radius: 50%; background: darkred; color: white; padding: 6px;"
-                                      title="Click to change to Yes"><?= ucfirst($attended) ?></span>
-                            </a>
-                            <a href="#" data-rsvp-id="<?= $rsvp_id ?>" class="button attended attended-email">
-                                <span class="dashicons dashicons-email-alt"
-                                      style="border-radius: 50%; background: darkred; color: white; padding: 6px;"
-                                      title="Click to email attendee">Email</span>
+                            <a href="<?= $setAttendedUrl ?>" class="button action attended attended-<?= $attended ?>">
+                                <span class="dashicons dashicons-editor-help" style="color: gray; font-size: 2.8rem; overflow: visible;"
+                                      title="Click to change to Yes"></span>
                             </a>
                         <?php
                         else: ?>
@@ -157,7 +151,18 @@ function embed_rsvp_events_single()
                         <?php
                         endif; ?>
                     </td>
-                    <td><a href="<?= get_delete_post_link($rsvp_id) ?>">Delete</a></td>
+                    <td data-th="actions" width="20%">
+                        <a href="<?= get_delete_post_link($rsvp_id) ?>" data-name="<?= $name ?>" class="button action delete-rsvp js-delete-rsvp">
+                                <span class="dashicons dashicons-no"
+                                      style="border-radius: 50%; background: darkred; color: white; padding: 6px;"
+                                      title="Click to delete RSVP">Delete</span>
+                        </a>
+                        <a href="#" data-rsvp-id="<?= $rsvp_id ?>" data-email="<?= $email ?>" class="button action attended-email">
+                                <span class="dashicons dashicons-email-alt"
+                                      style="border-radius: 50%; background: deepskyblue; color: white; padding: 6px;"
+                                      title="Click to email attendee">Email</span>
+                        </a>
+                    </td>
                 </tr>
 
                 <?php

--- a/plugin_customizations/tribe_events/tribe_events_scripts.php
+++ b/plugin_customizations/tribe_events/tribe_events_scripts.php
@@ -1,0 +1,14 @@
+<?php
+
+add_action('wp_enqueue_scripts', static function () {
+    $assetsUrl  = SDRT_FUNCTIONS_URL . 'assets/';
+    $assetsPath = SDRT_FUNCTIONS_DIR . '/assets/';
+
+    wp_enqueue_script(
+        'sdrt-event-single',
+        "$assetsUrl/event-single.js",
+        ['jquery'],
+        filemtime("$assetsPath/event-single.js"),
+        true
+    );
+});

--- a/rsvps/_rsvp.php
+++ b/rsvps/_rsvp.php
@@ -51,3 +51,22 @@ function get_event_rsvps(int $event_id, array $args = []): array
 
     return get_rsvps($args);
 }
+
+/**
+ * Retrieves the Event for a given RSVP id or post
+ *
+ * @param int|WP_Post $rsvp
+ *
+ * @return WP_Post|null
+ */
+function get_rsvp_event($rsvp): ?WP_Post
+{
+    $rsvp_id  = $rsvp instanceof WP_Post ? $rsvp->ID : (int)$rsvp;
+    $event_id = get_post_meta($rsvp_id, 'event_id', true);
+
+    if (empty($event_id)) {
+        return null;
+    }
+
+    return tribe_get_event($event_id);
+}

--- a/rsvps/_rsvp.php
+++ b/rsvps/_rsvp.php
@@ -3,6 +3,7 @@
 require_once(SDRT_FUNCTIONS_DIR . '/rsvps/attendance.php');
 require_once(SDRT_FUNCTIONS_DIR . '/rsvps/admin_menu.php');
 require_once(SDRT_FUNCTIONS_DIR . '/rsvps/crons.php');
+require_once(SDRT_FUNCTIONS_DIR . '/rsvps/ajax.php');
 
 /**
  * Helper functions for RSVPs
@@ -40,7 +41,7 @@ function get_rsvps(array $args = []): array
  */
 function get_event_rsvps(int $event_id, array $args = []): array
 {
-    $meta_query = $args['meta_query'] ?: [];
+    $meta_query = $args['meta_query'] ?? [];
 
     $meta_query[] = [
         'key'   => 'event_id',

--- a/rsvps/admin_menu.php
+++ b/rsvps/admin_menu.php
@@ -46,6 +46,17 @@ $example_fields = array(
         'desc'    => 'The following email tags are supported: <ul ><li><code>{first_name}</code></li><li><code>{event_title}</code></li></ul>',
         'sanit'   => 'html',
     ),
+    'sdrt_email_section_4' => array(
+        'title'   => 'Attendee No-Show Message',
+        'type'    => 'section',
+        'desc'    => 'This is manually sent to attendees that RSVP\'d but did not attend the event',
+    ),
+    'sdrt_rsvp_no_show' => array(
+        'title'   => 'Message',
+        'type'    => 'textarea',
+        'desc'    => 'The following email tags are supported: <ul ><li><code>{first_name}</code></li><li><code>{event_title}</code></li></ul>',
+        'sanit'   => 'html',
+    ),
 );
 
 $example_settings = new HD_WP_Settings_API( $example_options, $example_fields );

--- a/rsvps/ajax.php
+++ b/rsvps/ajax.php
@@ -1,0 +1,39 @@
+<?php
+
+function sdrt_rsvp_email_no_show()
+{
+    $nonce = $_POST['nonce'] ?? null;
+    if (empty($nonce) || ! wp_verify_nonce($nonce, 'sdrt_attendance_nonce') || ! current_user_can('can_view_rsvps')) {
+        wp_send_json_error(null, 403);
+    }
+
+    $rsvp_id = $_POST['rsvp_id'] ?? null;
+    if (empty($rsvp_id)) {
+        wp_send_json_error('Argument missing', 400);
+    }
+
+    $event = get_rsvp_event($rsvp_id);
+    if ($event === null) {
+        wp_send_json_error('Invalid RSVP', 400);
+    }
+
+    $volunteer_name  = get_post_meta($rsvp_id, 'volunteer_name', true);
+    $volunteer_email = get_post_meta($rsvp_id, 'volunteer_email', true);
+
+    wp_mail(
+        $volunteer_email,
+        "We missed you at {$event->post_title}",
+        sdrt_send_email([
+            'option'      => 'sdrt_rsvp_no_show',
+            'fname'       => trim(explode(',', $volunteer_name)[1] ?: ''),
+            'event_title' => $event->post_title,
+        ]),
+        [
+            'From: SD Refugee Tutoring <info@sdrefugeetutoring.com>',
+        ]
+    );
+
+    wp_send_json_success();
+}
+
+add_action('wp_ajax_sdrt_rsvp_email_no_show', 'sdrt_rsvp_email_no_show');

--- a/rsvps/ajax.php
+++ b/rsvps/ajax.php
@@ -22,7 +22,7 @@ function sdrt_rsvp_email_no_show()
 
     wp_mail(
         $volunteer_email,
-        "We missed you at {$event->post_title}",
+        "We Missed You!",
         sdrt_send_email([
             'option'      => 'sdrt_rsvp_no_show',
             'fname'       => trim(explode(',', $volunteer_name)[1] ?: ''),


### PR DESCRIPTION
Resolves #29 

## Description

This PR provides the ability for an admin to be able to send a no-show email to attendees of an event that did not show up or were unknown. The admin simply clicks an email button next to the attendees name and the email is sent.

The email message can be updated via the RSVP Email Settings and supports the `{first_name}` and `{event_title}` tags.

There were a number of formatting clean ups and optimizations included in this as well. I'm doing some basic auditing of code and looking for opportunities to make things faster and more efficient.

## Visuals

![Example of sending email](https://p179.p0.n0.cdn.getcloudapp.com/items/4gu1XO0g/de8623c3-3178-4d71-9921-4a5f01e8d254.gif?v=d91df75b262b81d338e36b1f55738ec2)