### PR TITLE
Improve features for background checks

### DIFF
--- a/admin/_admin.php
+++ b/admin/_admin.php
@@ -2,4 +2,5 @@
 
 require_once( SDRT_FUNCTIONS_DIR . '/admin/admin_columns.php');
 require_once( SDRT_FUNCTIONS_DIR . '/admin/better_cpt_search.php');
+require_once( SDRT_FUNCTIONS_DIR . '/admin/user_edit.php');
 require_once( SDRT_FUNCTIONS_DIR . '/admin/emails/email_templates.php');

--- a/admin/user_edit.php
+++ b/admin/user_edit.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Add the "Clear Background Check" to the Users bulk actions
+ */
+add_filter('bulk_actions-users', static function (array $actions): array {
+    if ( ! current_user_can('manage_volunteers')) {
+        return $actions;
+    }
+
+    return array_merge($actions, [
+        'sdrt_clear_background_check' => 'Clear Background Check',
+    ]);
+});
+
+/**
+ * Handle the "Clear Background Check" bulk action
+ */
+add_filter('handle_bulk_actions-users', static function (string $redirectUrl, string $action, array $userIds): string {
+    if ($action !== 'sdrt_clear_background_check' || ! current_user_can('manage_volunteers')) {
+        return $redirectUrl;
+    }
+
+    foreach ($userIds as $userId) {
+        update_user_meta($userId, 'background_check', 'No');
+        delete_user_meta($userId, 'background_check_invite_url');
+    }
+
+    return add_query_arg('sdrt-cleared-background', count($userIds), $redirectUrl);
+}, 10, 3);
+
+add_action('admin_notices', static function () {
+    if (empty($_GET['sdrt-cleared-background'])) {
+        return;
+    }
+
+    $usersCleared = (int)$_GET['sdrt-cleared-background'];
+
+    echo "
+        <div id='message' class='updated notice is-dismissible'><p>
+            Background checks cleared for $usersCleared users
+        </p></div>
+    ";
+});

--- a/admin/user_edit.php
+++ b/admin/user_edit.php
@@ -24,7 +24,7 @@ add_filter('handle_bulk_actions-users', static function (string $redirectUrl, st
     }
 
     foreach ($userIds as $userId) {
-        update_user_meta($userId, 'background_check', 'No');
+        update_user_meta($userId, 'background_check', 'Cleared');
         delete_user_meta($userId, 'background_check_invite_url');
     }
 
@@ -32,15 +32,91 @@ add_filter('handle_bulk_actions-users', static function (string $redirectUrl, st
 }, 10, 3);
 
 add_action('admin_notices', static function () {
-    if (empty($_GET['sdrt-cleared-background'])) {
-        return;
-    }
+    if ( ! empty($_GET['sdrt-cleared-background'])) {
+        $usersCleared = (int)$_GET['sdrt-cleared-background'];
 
-    $usersCleared = (int)$_GET['sdrt-cleared-background'];
-
-    echo "
+        echo "
         <div id='message' class='updated notice is-dismissible'><p>
             Background checks cleared for $usersCleared users
         </p></div>
     ";
+    }
+
+    if ( !empty($_GET['sdrt-request-new-invitation']) ) {
+        $problem = true;
+        switch($_GET['sdrt-request-new-invitation']) {
+            case 'no-date-of-birth':
+                $message = 'A date of birth is required to register for a new background check.';
+                break;
+
+            case 'invalid-candidate':
+                $message = 'There was an issue creating a Checkr Candidate, please try again and contact a site administrator if the problem persists.';
+                break;
+
+            case 'invalid-invitation':
+                $message = 'There was an issue creating a Checkr Invitation, please try again and contact a site administrator if the problem persists.';
+                break;
+
+            default:
+                $message = 'You have successfully registered for a new background check. A new invitation will be sent to your email.';
+                $problem = false;
+                break;
+        }
+
+        $noticeClass = $problem ? 'error notice-error' : 'updated';
+        echo "<div id='message' class='notice is-dismissible $noticeClass'><p>$message</p></div>";
+    }
+});
+
+add_action('admin_init', static function () {
+    if (empty($_GET['sdrt-request-new-invitation'])) {
+        return;
+    }
+
+    /** @var WP_User $user */
+    $user = wp_get_current_user();
+    $candidateId = get_user_meta($user->ID, 'background_check_candidate_id', true);
+
+    if (empty($candidateId)) {
+        $dateOfBirth = get_user_meta($user->ID, 'your_date_of_birth', true);
+
+        if (empty($dateOfBirth)) {
+            $_GET['sdrt-request-new-invitation'] = 'no-date-of-birth';
+
+            return;
+        }
+
+        $candidate = sdrtCreateCheckrCandidate(
+            $user->first_name,
+            $user->last_name,
+            $user->user_email,
+            new DateTime($dateOfBirth)
+        );
+
+        if (is_wp_error($candidate)) {
+            $_GET['sdrt-request-new-invitation'] = 'invalid-candidate';
+
+            return;
+        }
+
+        $candidateId = $candidate->id;
+        update_user_meta($user->ID, 'background_check_candidate_id', $candidateId);
+    }
+
+    $inviteUrl = get_user_meta($user->ID, 'background_check_invite_url', true);
+    if ( ! empty($inviteUrl)) {
+        return;
+    }
+
+    $invitation = sdrtCreateCheckrInvitation($candidateId);
+
+    if (is_wp_error($invitation)) {
+        $_GET['sdrt-request-new-invitation'] = 'invalid-invitation';
+
+        return;
+    }
+
+    update_user_meta($user->ID, 'background_check_invite_url', $candidateId);
+
+    wp_safe_redirect(remove_query_arg('sdrt-request-new-invitation'));
 });

--- a/assets/admin-user-edit.js
+++ b/assets/admin-user-edit.js
@@ -1,0 +1,19 @@
+window.addEventListener('DOMContentLoaded', async function () {
+    const button = document.querySelector('.js-sdrt-new-background-check');
+
+    if (button === null) {
+        return;
+    }
+
+    button.addEventListener('click', async function (event) {
+        event.preventDefault();
+
+        try {
+            const response = fetch(`${ajaxurl}?action=sdrt_new_background_check`, {
+                method: 'GET',
+            });
+        } catch(e) {
+            console.log(e);
+        }
+    });
+});

--- a/assets/admin-user-edit.js
+++ b/assets/admin-user-edit.js
@@ -5,15 +5,45 @@ window.addEventListener('DOMContentLoaded', async function () {
         return;
     }
 
+    function showError(message) {
+        const notice = document.createElement('div');
+        notice.style.backgroundColor = '#ff8295';
+        notice.style.margin = '0.5em 0';
+        notice.style.padding = '1em';
+        notice.style.fontWeight = 'bold';
+        notice.textContent = `There was an error generating the background check. Please report the following to a website admin: ${message}`;
+
+        button.parentElement.append(notice)
+    }
+
     button.addEventListener('click', async function (event) {
         event.preventDefault();
 
         try {
-            const response = fetch(`${ajaxurl}?action=sdrt_new_background_check`, {
+            const urlParams = new URLSearchParams(window.location.search);
+            const response = await fetch(`${ajaxurl}?action=sdrt_new_background_check&user_id=${urlParams.get('user_id')}`, {
                 method: 'GET',
             });
-        } catch(e) {
-            console.log(e);
+            const {data, success} = await response.json();
+
+            if ( !success) {
+                showError(data);
+                return;
+            }
+
+            if (data.candidate_id) {
+                const candidateIdText = document.querySelector('input[name="background_check_candidate_id"]');
+                candidateIdText.value = data.candidate_id;
+            }
+
+            if (data.invitation_url) {
+                const inviteUrlText = document.querySelector('input[name="background_check_invite_url"]');
+                inviteUrlText.value = data.invitation_url;
+            }
+
+            button.remove();
+        } catch (e) {
+            showError(e.message);
         }
     });
 });

--- a/checkr/functions.php
+++ b/checkr/functions.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @return object|WP_Error
+ */
+function sdrtCreateCheckrCandidate(string $firstName, string $lastName, string $email, DateTime $dateOfBirth): object
+{
+    $response = wp_remote_post('https://api.checkr.com/v1/candidates', [
+        'headers' => [
+            'Authorization' => 'Basic ' . base64_encode(SDRT_CHECKR_API . ':' . ''),
+        ],
+        'body' => [
+            'first_name' => $firstName,
+            'no_middle_name' => true,
+            'last_name' => $lastName,
+            'email' => $email,
+            'dob' => $dateOfBirth->format('Y-m-d'),
+        ],
+    ]);
+
+    if (is_wp_error($response)) {
+        return $response;
+    }
+
+    return json_decode(wp_remote_retrieve_body($response), false);
+}
+
+/**
+ * @return object|WP_Error
+ */
+function sdrtCreateCheckrInvitation(string $candidateId): object
+{
+    $response = wp_remote_post('https://api.checkr.com/v1/invitations', [
+        'headers' => [
+            'Authorization' => 'Basic ' . base64_encode(SDRT_CHECKR_API . ':' . ''),
+        ],
+        'body' => [
+            'package' => 'tasker_standard',
+            'candidate_id' => $candidateId,
+        ],
+    ]);
+
+    if (is_wp_error($response)) {
+        return $response;
+    }
+
+    return json_decode(wp_remote_retrieve_body($response), false);
+}

--- a/includes/sdrt_scripts.php
+++ b/includes/sdrt_scripts.php
@@ -43,11 +43,16 @@ function load_custom_wp_admin_style() {
 add_action('admin_enqueue_scripts', 'sdrt_rsvp_admin_styles');
 
 function sdrt_rsvp_admin_styles( $hook ) {
+    $screen = get_current_screen();
 	
 	wp_register_style( 'custom_wp_admin_css', SDRT_FUNCTIONS_URL . '/assets/admin-style.css', false, '1.0.0' );
 	wp_enqueue_style( 'custom_wp_admin_css' );
 	wp_enqueue_style( 'font-awesome-5', 'https://use.fontawesome.com/releases/v5.9.0/css/all.css', array(), FL_THEME_VERSION );
-	
+
+	if ( $screen->base === 'user-edit' ) {
+        wp_enqueue_script('sdrt_user_edit', SDRT_FUNCTIONS_URL . '/assets/admin-user-edit.js', [], '', true);
+    }
+
 	global $post_type;
 
 	// Only for the Events Calendar Edit pages

--- a/includes/sdrt_user_meta.php
+++ b/includes/sdrt_user_meta.php
@@ -12,15 +12,15 @@ function sdrt_user_meta_fields( $user ) { ?>
 
 		$userid = (is_admin()) ? $user->ID : get_current_user_id();
 
-		$background_check_status = get_user_meta( $userid, 'background_check', false );
-		$orientation = get_user_meta( $userid, 'sdrt_orientation_attended', false );
-		$coc = get_user_meta( $userid, 'sdrt_coc_consented', false );
-		$waiver = get_user_meta( $userid, 'sdrt_waiver_consented', false );
+		$background_check_status = get_user_meta( $userid, 'background_check', true );
+		$orientation = get_user_meta( $userid, 'sdrt_orientation_attended', true );
+		$coc = get_user_meta( $userid, 'sdrt_coc_consented', true );
+		$waiver = get_user_meta( $userid, 'sdrt_waiver_consented', true );
 
-		$background_check_invite_url = get_user_meta( $userid, 'background_check_invite_url', false );
+		$background_check_invite_url = get_user_meta( $userid, 'background_check_invite_url', true );
 		$background_check_candidate_id = get_user_meta( $userid, 'background_check_candidate_id', true );
 
-		switch ( $background_check_status[0] ) {
+		switch ( $background_check_status ) {
 			case 'Yes':
 				$background_check['icon'] = '<i class="fa fa-check-circle"></i>';
 				$background_check['status'] = 'status-cleared';
@@ -36,73 +36,44 @@ function sdrt_user_meta_fields( $user ) { ?>
 			case 'Invited':
 				$background_check['icon'] = '<i class="fa fa-question-circle"></i>';
 				$background_check['status'] = 'status-pending';
-				$background_check['message'] = 'You have been invited to take a background check and your status is still pending. You can check on the status at <a href="' . $background_check_invite_url[0] . '" target="_blank" rel="noopener noreferrer">the Checkr website</a>.';
+				$background_check['message'] = 'You have been invited to take a background check and your status is still pending. You can check on the status at <a href="' . $background_check_invite_url . '" target="_blank" rel="noopener noreferrer">the Checkr website</a>.';
 				break;
 		}
 
-		switch ( $orientation[0] ) {
-			case 'Yes':
-				$orientation_status['icon'] = '<i class="fa fa-check-circle"></i>';
-				$orientation_status['status'] = 'status-cleared';
-				$orientation_status['message'] = 'You have <span>attended</span> an orientation session. Thank you!';
-				break;
-			
-			default :
-				$orientation_status['icon'] = '<i class="fa fa-times-circle"></i>';
-				$orientation_status['status'] = 'status-failed';
-				$orientation_status['message'] = 'You have <span>not yet attended</span> an orientation session. Please see <a href="' . get_home_url(). '/events" target="_blank" rel="noopener noreferrer">our calendar</a> to RSVP for an upcoming session.';
-				break;
-		}
+    if ($orientation === 'Yes') {
+        $orientation_status['icon'] = '<i class="fa fa-check-circle"></i>';
+        $orientation_status['status'] = 'status-cleared';
+        $orientation_status['message'] = 'You have <span>attended</span> an orientation session. Thank you!';
+    } else {
+        $orientation_status['icon'] = '<i class="fa fa-times-circle"></i>';
+        $orientation_status['status'] = 'status-failed';
+        $orientation_status['message'] = 'You have <span>not yet attended</span> an orientation session. Please see <a href="' . get_home_url() . '/events" target="_blank" rel="noopener noreferrer">our calendar</a> to RSVP for an upcoming session.';
+    }
 
-		switch ( $coc[0] ) {
-			case 'Yes':
-				$coc_status['icon'] = '<i class="fa fa-check-circle"></i>';
-				$coc_status['status'] = 'status-cleared';
-				$coc_status['message'] = 'You have <span>indicated your consent</span> to our Code of Conduct. Thank you!';
-				break;
-			
-			default:
-				$coc_status['icon'] = '<i class="fa fa-times-circle"></i>';
-				$coc_status['status'] = 'status-failed';
-				$coc_status['message'] = 'You have <span>not yet indicated your consent</span> to our Code of Conduct. <a href="' . get_home_url() . '/code-of-conduct">Please do that here</a>.';
-				break;
-		}
+    if ($coc === 'Yes') {
+        $coc_status['icon'] = '<i class="fa fa-check-circle"></i>';
+        $coc_status['status'] = 'status-cleared';
+        $coc_status['message'] = 'You have <span>indicated your consent</span> to our Code of Conduct. Thank you!';
+    } else {
+        $coc_status['icon'] = '<i class="fa fa-times-circle"></i>';
+        $coc_status['status'] = 'status-failed';
+        $coc_status['message'] = 'You have <span>not yet indicated your consent</span> to our Code of Conduct. <a href="' . get_home_url() . '/code-of-conduct">Please do that here</a>.';
+    }
 
-		switch ( $waiver[0] ) {
-			case 'Yes':
-				$waiver_status['icon'] = '<i class="fa fa-check-circle"></i>';
-				$waiver_status['status'] = 'status-cleared';
-				$waiver_status['message'] = 'You have <span>indicated your consent</span> to our Volunteer Release Policy. Thank you!';
-				break;
-			
-			default:
-				$waiver_status['icon'] = '<i class="fa fa-times-circle"></i>';
-				$waiver_status['status'] = 'status-failed';
-				$waiver_status['message'] = 'You have <span>not yet indicated your consent</span> to our Volunteer Release & Waiver of Liability Policy. <a href="' . get_home_url() . '/volunteer-release">Please do that here</a>.';
-				break;
-		}
+    if ($waiver === 'Yes') {
+        $waiver_status['icon'] = '<i class="fa fa-check-circle"></i>';
+        $waiver_status['status'] = 'status-cleared';
+        $waiver_status['message'] = 'You have <span>indicated your consent</span> to our Volunteer Release Policy. Thank you!';
+    } else {
+        $waiver_status['icon'] = '<i class="fa fa-times-circle"></i>';
+        $waiver_status['status'] = 'status-failed';
+        $waiver_status['message'] = 'You have <span>not yet indicated your consent</span> to our Volunteer Release & Waiver of Liability Policy. <a href="' . get_home_url() . '/volunteer-release">Please do that here</a>.';
+    }
 	?>
 
 	<?php
 	
 	if ( !current_user_can( 'can_view_rsvps' ) ) : 
-	/* TESTING PURPOSES
-	echo "user_id =" . $userid . "<br />";
-	echo "background_check_status = " .  $background_check_status[0] . "<br />";
-	var_dump($background_check);
-
-	echo "orientation = " .  $orientation[0];
-	var_dump($orientation_status);
-
-	echo "coc_status = " .  $coc[0];
-	var_dump($coc_status);
-
-	echo "media_status = " .  $media[0];
-	var_dump($media_status);
-
-	
-	*/
-	//var_dump(get_user_meta($userid));
 	?>
 	<div class="vol-reqs">
 		<!-- Volunteer View of the Admin Profile Editor -->
@@ -177,11 +148,14 @@ function sdrt_user_meta_fields( $user ) { ?>
 			</p>
 			<p class="checkr-info">
 				<strong>This volunteer's Invite link is:</strong><br />
-				<input type="text" name="background_check_invite_url" value="<?php echo $background_check_invite_url[0]; ?>" readonly size="75">
+				<input type="text" name="background_check_invite_url" value="<?php echo $background_check_invite_url; ?>" readonly size="75">
 			</p>
 			<p><strong>This volunteer's Candidate ID is:</strong><br />
 				<input type="text" name="background_check_candidate_id" value="<?php echo $background_check_candidate_id; ?>" readonly size="75">
 			</p>
+            <?php if ( empty($background_check_candidate_id) && empty($background_check_invite_url) ): ?>
+                <button class="button js-sdrt-new-background-check">Request New Background Check</button>
+            <?php endif; ?>
 		</div>
 
 		<!-- ORIENTATION STATUS -->
@@ -190,9 +164,9 @@ function sdrt_user_meta_fields( $user ) { ?>
 			<p class="description">This setting must be changed manually by anyone with an SDRT Leadership Role. It is not ever updated automatically.</p>
 			<p class="status">
 				<select name="sdrt_orientation_attended" id="sdrt_orientation_attended">
-					<option value="No" <?php  selected( $orientation[0], 'No' ); ?> >NO -- this volunteer has not yet attended an orientation.</option>
+					<option value="No" <?php  selected( $orientation, 'No' ); ?> >NO -- this volunteer has not yet attended an orientation.</option>
 
-					<option value="Yes" <?php  selected( $orientation[0], 'Yes' ); ?> >YES -- this volunteer attended an orientation.</option>
+					<option value="Yes" <?php  selected( $orientation, 'Yes' ); ?> >YES -- this volunteer attended an orientation.</option>
 				</select>
 			</p>
 		</div>
@@ -203,9 +177,9 @@ function sdrt_user_meta_fields( $user ) { ?>
 			<p class="description">This is set to "No" by default for all users. It will be updated automatically once the user has completed the Code of Conduct Form.</p>
 			<p class="status">
 			<select name="sdrt_coc_consented" id="sdrt_coc_consented">
-				<option value="No" <?php  selected( $coc[0], 'No' ); ?> >NO -- this volunteer has not consented to the SDRT Code of Conduct.</option>
+				<option value="No" <?php  selected( $coc, 'No' ); ?> >NO -- this volunteer has not consented to the SDRT Code of Conduct.</option>
 
-				<option value="Yes" <?php  selected( $coc[0], 'Yes' ); ?> >YES -- this volunteer has consented to the SDRT Code of Conduct.</option>
+				<option value="Yes" <?php  selected( $coc, 'Yes' ); ?> >YES -- this volunteer has consented to the SDRT Code of Conduct.</option>
 			</select>
 			</p>
 		</div>
@@ -216,9 +190,9 @@ function sdrt_user_meta_fields( $user ) { ?>
 			<p class="description">This is automatically set to "No" by default for all users. It will be updated automatically once the user has completed the Volunteer Release & Waiver Form.</p>
 			<p class="status">
 				<select name="sdrt_waiver_consented" id="sdrt_waiver_consented">
-					<option value="No" <?php  selected( $waiver[0], 'No' ); ?> >NO -- this volunteer has not consented to the SDRT Volunteer Release & Waiver of Liability.</option>
+					<option value="No" <?php  selected( $waiver, 'No' ); ?> >NO -- this volunteer has not consented to the SDRT Volunteer Release & Waiver of Liability.</option>
 
-					<option value="Yes" <?php  selected( $waiver[0], 'Yes' ); ?> >YES -- this volunteer has consented to the Volunteer Release & Waiver of Liability.</option>
+					<option value="Yes" <?php  selected( $waiver, 'Yes' ); ?> >YES -- this volunteer has consented to the Volunteer Release & Waiver of Liability.</option>
 				</select>
 			</p>
 		</div>

--- a/registration/ajax.php
+++ b/registration/ajax.php
@@ -1,35 +1,49 @@
 <?php
 
 add_action('wp_ajax_sdrt_new_background_check', function () {
-    global $user;
+    if (empty($_GET['user_id'])) {
+        wp_send_json_error('Invalid use of action');
+    }
+
+    $user = get_user_by('id', $_GET['user_id']);
 
     if ( ! $user instanceof WP_User) {
         wp_send_json_error('Invalid use of action');
     }
 
-    $dateOfBirth = get_user_meta($user->ID, 'your_date_of_birth', true);
-    if (empty($dateOfBirth)) {
-        wp_send_json_error('User must have date of birth set');
+    $candidateId = get_user_meta($user->ID, 'background_check_candidate_id', true);
+
+    if (empty($candidateId)) {
+        $dateOfBirth = get_user_meta($user->ID, 'your_date_of_birth', true);
+        if (empty($dateOfBirth)) {
+            wp_send_json_error('User must have date of birth set');
+        }
+
+        $candidate = sdrtCreateCheckrCandidate(
+            $user->first_name,
+            $user->last_name,
+            $user->user_email,
+            new DateTime($dateOfBirth)
+        );
+
+        if (is_wp_error($candidate)) {
+            wp_send_json_error("Failed to create Checkr Candidate: {$candidate->get_error_message()}");
+        }
+
+        $candidateId = $candidate->id;
+        update_user_meta($user->ID, 'background_check_candidate_id', $candidate->id);
     }
 
-    $candidate = sdrtCreateCheckrCandidate(
-        $user->first_name,
-        $user->last_name,
-        $user->email,
-        new DateTime($dateOfBirth)
-    );
-
-    if (is_wp_error($candidate)) {
-        wp_send_json_error("Failed to create Checkr Candidate: {$candidate->get_error_message()}");
-    }
-
-    update_user_meta($user->ID, 'background_check_candidate_id', $candidate->id);
-
-    $invitation = sdrtCreateCheckrInvitation($candidate->id);
+    $invitation = sdrtCreateCheckrInvitation($candidateId);
 
     if (is_wp_error($invitation)) {
         wp_send_json_error("Failed to create Checkr Candidate: {$invitation->get_error_message()}");
     }
 
     update_user_meta($user->ID, 'background_check_invite_url', $invitation->invitation_url);
+
+    wp_send_json_success([
+        'candidate_id' => $candidateId,
+        'invitation_url' => $invitation->invitation_url,
+    ]);
 });

--- a/registration/ajax.php
+++ b/registration/ajax.php
@@ -1,0 +1,35 @@
+<?php
+
+add_action('wp_ajax_sdrt_new_background_check', function () {
+    global $user;
+
+    if ( ! $user instanceof WP_User) {
+        wp_send_json_error('Invalid use of action');
+    }
+
+    $dateOfBirth = get_user_meta($user->ID, 'your_date_of_birth', true);
+    if (empty($dateOfBirth)) {
+        wp_send_json_error('User must have date of birth set');
+    }
+
+    $candidate = sdrtCreateCheckrCandidate(
+        $user->first_name,
+        $user->last_name,
+        $user->email,
+        new DateTime($dateOfBirth)
+    );
+
+    if (is_wp_error($candidate)) {
+        wp_send_json_error("Failed to create Checkr Candidate: {$candidate->get_error_message()}");
+    }
+
+    update_user_meta($user->ID, 'background_check_candidate_id', $candidate->id);
+
+    $invitation = sdrtCreateCheckrInvitation($candidate->id);
+
+    if (is_wp_error($invitation)) {
+        wp_send_json_error("Failed to create Checkr Candidate: {$invitation->get_error_message()}");
+    }
+
+    update_user_meta($user->ID, 'background_check_invite_url', $invitation->invitation_url);
+});

--- a/sdrt_custom_functions.php
+++ b/sdrt_custom_functions.php
@@ -49,4 +49,6 @@ function sdrt_includes() {
 	// Bootstrapper for the RSVP functionality
     require_once( SDRT_FUNCTIONS_DIR . '/rsvps/_rsvp.php');
 
+    // Bootstrapper for the Checkr functionality
+    require_once( SDRT_FUNCTIONS_DIR . '/checkr/functions.php');
 }


### PR DESCRIPTION
Resolves #39 

This PR adds three features surrounding the improvement to the annual flow of background checks:

### 1. Clear background checks
Admins and SDRT Leadership have a new bulk action when viewing the Users table to clear a volunteer's background check:
![Image 2021-07-31 at 10 08 25 PM](https://user-images.githubusercontent.com/2024145/127759915-0596e849-c3ba-4336-8aac-fa5435db3dc4.jpg)

The "Background Check" has been added to the Users table for clarity. Once a volunteer has been cleared, their Background Check status will go to "Cleared".

### 2. Cleared volunteer requests new background check
Volunteers that have been cleared from a previous year will see a new screen when viewing their profile:
![Image 2021-07-31 at 10 07 53 PM](https://user-images.githubusercontent.com/2024145/127759946-5c2d2b79-75e8-40b1-9b8c-a5e22a04894f.jpg)

Using the new button, the volunteer may request a new background check to be triggered. Once the background check has been triggered, the volunteer will see a new message:
![Image 2021-07-31 at 10 08 04 PM](https://user-images.githubusercontent.com/2024145/127759953-87711fb7-104c-4422-ba58-9eaab54c1453.jpg)

### 3. Admin request background check

Admins and SDRT Leadership may also trigger a new background check for volunteers, if that volunteer is missing either a candidate id or invitation url:
![Image 2021-07-31 at 10 08 51 PM](https://user-images.githubusercontent.com/2024145/127759980-2ef41d8c-28e3-4724-9394-f391c6ba256a.jpg)

---

**Notes on Background Checks**
1. When a volunteer is cleared from a previous year, the invitation url is cleared, but not the candidate id. The reason for this is that the candidate id will be reused for the next check.
2. The system is smart enough to handle the candidate id and/or the invitation url missing. So if a volunteer somehow gets in a strange state, the system should be able to recover when the request is made.
3. If for some reason there's an issue with a volunteer's invitation url, just clear the user with the batch action and request a new background check.
